### PR TITLE
Changes for compatibility with DIALS v1 & v2

### DIFF
--- a/screen19/__init__.py
+++ b/screen19/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 
 """
 Common tools for the I19 module.
@@ -12,11 +12,16 @@ import traceback
 import procrunner
 from typing import Dict, Tuple
 
+import dials.util.version
+
 __version__ = "0.204"
 
 logger = logging.getLogger("dials.screen19")
 debug, info, warn = logger.debug, logger.info, logger.warning
 
+
+# Check whether we need to be using DIALS v1 API
+dials_v1 = dials.util.version.__dials_version_default.startswith("1.")
 
 # Set axis tick positions manually.  Accounts for reciprocal(-square) d-scaling.
 d_ticks = [5, 3, 2, 1.5, 1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4]

--- a/screen19/__init__.py
+++ b/screen19/__init__.py
@@ -23,7 +23,7 @@ debug, info, warn = logger.debug, logger.info, logger.warning
 
 
 # Check whether we need to be using DIALS v1 API
-dials_v1 = dials.util.version.__dials_version_default.startswith("1.")
+dials_v1 = dials.util.version.dials_version().startswith("DIALS 1.")
 
 # Set axis tick positions manually.  Accounts for reciprocal(-square) d-scaling.
 d_ticks = [5, 3, 2, 1.5, 1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4]

--- a/screen19/__init__.py
+++ b/screen19/__init__.py
@@ -4,6 +4,8 @@
 Common tools for the I19 module.
 """
 
+from __future__ import absolute_import, division, print_function
+
 import os
 import sys
 import re

--- a/screen19/__init__.py
+++ b/screen19/__init__.py
@@ -107,7 +107,7 @@ def plot_intensities(
     hist_value_factor,
     title="'Pixel intensity distribution'",
     xlabel="'% of maximum'",
-    ylabel="'Number of observed pixels'",
+    ylabel="'Number of pixels'",
     xticks="",
     style="with boxes",
     procrunner_debug=False,

--- a/screen19/__init__.py
+++ b/screen19/__init__.py
@@ -10,7 +10,8 @@ import re
 import logging
 import traceback
 import procrunner
-from typing import Dict, Tuple
+from typing import Dict, Tuple  # noqa: F401
+# Flake8 does not detect typing yet (https://gitlab.com/pycqa/flake8/issues/342)
 
 import dials.util.version
 

--- a/screen19/__init__.py
+++ b/screen19/__init__.py
@@ -1,8 +1,6 @@
 # coding: utf-8
 
-"""
-Common tools for the I19 module.
-"""
+"""Common tools for the I19 module."""
 
 from __future__ import absolute_import, division, print_function
 
@@ -164,17 +162,17 @@ def plot_intensities(
     if result["exitcode"] == 0:
         star = re.compile(r"\*")
         state = set()
-        for l in result["stdout"].split("\n"):
-            if l.strip() != "":
-                stars = {m.start(0) for m in re.finditer(star, l)}
+        for line in result["stdout"].split("\n"):
+            if line.strip() != "":
+                stars = {m.start(0) for m in re.finditer(star, line)}
                 if not stars:
                     state = set()
                 else:
                     state |= stars
-                    l = list(l)
+                    line = list(line)
                     for s in state:
-                        l[s] = "*"
-                info("".join(l))
+                        line[s] = "*"
+                info("".join(line))
     else:
         warn(
             "Error running gnuplot. Cannot plot intensity distribution. "

--- a/screen19/minimum_exposure.py
+++ b/screen19/minimum_exposure.py
@@ -18,19 +18,19 @@ translates trivially to a threshold I.
 
 The value of the fitted intensity function at the desired
 resolution is compared with the threshold I.  The ratio of these
-values is used to determine a recommended dose for the full data
-collection.
+values is used to determine a recommended exposure (flux × exposure time)
+for the full data collection.
 
 The Wilson plot of I as a function of d is drawn as the file
 'wilson_plot.png'.  The plot can optionally be saved in other formats.
 
 Examples:
 
-    screen19.minimum_dose integrated_experiments.json integrated.pickle
+    screen19.minimum_exposure integrated_experiments.json integrated.pickle
 
-    screen19.minimum_dose indexed_experiments.json indexed.pickle
+    screen19.minimum_exposure indexed_experiments.json indexed.pickle
 
-    screen19.minimum_dose min_i_over_sigma=2 desired_d=0.84 wilson_fit_max_d=4 \
+    screen19.minimum_exposure min_i_over_sigma=2 desired_d=0.84 wilson_fit_max_d=4 \
         integrated_experiments.json integrated.pickle
 
 """
@@ -86,22 +86,22 @@ else:
 
 phil_scope = iotbx.phil.parse(
     u"""
-    minimum_dose
-        .caption = 'Parameters for the calculation of the lower dose bound'
+    minimum_exposure
+        .caption = 'Parameters for the calculation of the lower exposure bound'
         {
         desired_d = None
             .multiple = True
             .type = float
             .caption = u'Desired resolution limit, in Ångströms, of diffraction data'
-            .help = 'This is the resolution target for the lower-bound dose ' \
+            .help = 'This is the resolution target for the lower-bound exposure ' \
                     'recommendation.'
         min_i_over_sigma = 2
             .type = float
-            .caption = u'Target I/σ value for lower-bound dose recommendation'
-            .help = 'The lower-bound dose recommendation provides an estimate of ' \
-                    'the dose required to ensure that the majority of expected ' \
-                    u'reflections at the desired resolution limit have I/σ greater ' \
-                    'than or equal to this value.'
+            .caption = u'Target I/σ value for lower-bound exposure recommendation'
+            .help = 'The lower-bound exposure recommendation provides an estimate of ' \
+                    u'the exposure (flux × exposure time) required to ensure that the' \
+                    'majority of expected reflections at the desired resolution limit' \
+                    u'have I/σ greater than or equal to this value.'
         wilson_fit_max_d = 4  # Å
             .type = float
             .caption = u'Maximum d-value (in Ångströms) for displacement parameter fit'
@@ -111,10 +111,10 @@ phil_scope = iotbx.phil.parse(
     output
         .caption = 'Parameters to control the output'
         {
-        log = 'screen19.minimum_dose.log'
+        log = 'screen19.minimum_exposure.log'
             .type = str
             .caption = 'Location for the info log'
-        debug_log = 'screen19.minimum_dose.debug.log'
+        debug_log = 'screen19.minimum_exposure.debug.log'
             .type = str
             .caption = 'Location for the debug log'
         wilson_plot = 'wilson_plot'
@@ -128,7 +128,7 @@ phil_scope = iotbx.phil.parse(
     process_includes=True,
 )
 
-logger_name = "dials.screen19.minimum_dose"
+logger_name = "dials.screen19.minimum_exposure"
 logger = logging.getLogger(logger_name)
 debug, info, warn = logger.debug, logger.info, logger.warning
 
@@ -290,16 +290,16 @@ def wilson_plot_image(
     plt.close()
 
 
-def suggest_minimum_dose(expts, refls, params):
+def suggest_minimum_exposure(expts, refls, params):
     # type: (ExperimentList[Experiment], flex.reflection_table, scope_extract) -> None
     u"""
-    Suggest an estimated minimum sufficient dose to achieve a certain resolution.
+    Suggest an estimated minimum sufficient exposure to achieve a certain resolution.
 
     The estimate is based on a fit of a Debye-Waller factor under the assumption that a
     single isotropic displacement parameter can be used to adequately describe the
     decay of intensities with increasing sin(θ).
 
-    An ASCII-art Wilson plot is printed, along with minimum dose recommendations for
+    An ASCII-art Wilson plot is printed, along with minimum exposure recommendations for
     a number of different resolution targets.  The Wilson plot, including the fitted
     isotropic Debye-Waller factor, is saved as a PNG image.
 
@@ -307,7 +307,7 @@ def suggest_minimum_dose(expts, refls, params):
         expts: Experiment list containing a single experiment, from which the crystal
             symmetry will be extracted.
         refls: Reflection table of observed reflections.
-        params: Parameters for calculation of minimum dose estimate.
+        params: Parameters for calculation of minimum exposure estimate.
     """
     # Ignore reflections without an index, since uctbx.unit_cell.d returns spurious
     # d == -1 values, rather than None, for unindexed reflections.
@@ -322,12 +322,12 @@ def suggest_minimum_dose(expts, refls, params):
     except RuntimeError:
         refls = refls.select(refls["intensity.sum.value"] > 0)
 
-    # Parameters for the lower-bound dose estimate:
-    min_i_over_sigma = params.minimum_dose.min_i_over_sigma
-    wilson_fit_max_d = params.minimum_dose.wilson_fit_max_d
-    desired_d = params.minimum_dose.desired_d
+    # Parameters for the lower-bound exposure estimate:
+    min_i_over_sigma = params.minimum_exposure.min_i_over_sigma
+    wilson_fit_max_d = params.minimum_exposure.wilson_fit_max_d
+    desired_d = params.minimum_exposure.desired_d
     # If no target resolution is given, use the following defaults:
-    if not params.minimum_dose.desired_d:
+    if not params.minimum_exposure.desired_d:
         desired_d = [
             1,  # Å
             0.84,  # Å (IUCr publication requirement)
@@ -350,7 +350,7 @@ def suggest_minimum_dose(expts, refls, params):
     # Perform the Wilson plot fit
     fit = wilson_fit(d_star_sq, intensity, sigma, wilson_fit_max_d)
 
-    # Get recommended dose factors
+    # Get recommended exposure factors
     # Use the fact that σ² = I for indexed data, so I/σ = √̅I
     desired_d_star_sq = [1 / d ** 2 for d in desired_d]
     target_i = min_i_over_sigma ** 2
@@ -359,7 +359,7 @@ def suggest_minimum_dose(expts, refls, params):
         for target_d in desired_d_star_sq
     ]
 
-    # Get the achievable resolution at the current dose
+    # Get the achievable resolution at the current exposure
     desired_d += [np.sqrt(fit[0] / (2 * np.log(fit[1] / target_i)))]
     recommended_factor += [1]
 
@@ -375,28 +375,32 @@ def suggest_minimum_dose(expts, refls, params):
         if recommendation < 1:
             debug(
                 u"\nIt is likely that you can achieve a resolution of %g Å using a "
-                "lower dose.",
+                "lower exposure (lower transmission and/or shorter exposure time).",
                 target,
             )
         elif recommendation > 1:
             debug(
-                "\nIt is likely that you need a higher dose to achieve a "
-                u"resolution of %g Å.",
+                "\nIt is likely that you need a higher exposure (higher transmission "
+                u"and/or longer exposure time to achieve a resolution of %g Å.",
                 target,
             )
         debug(
-            u"The estimated minimal sufficient dose to achieve a resolution of %.2g Å "
-            "is %.3g times the dose used for this data collection.",
+            "The estimated minimal sufficient exposure (flux × exposure time) to "
+            u"achievea resolution of %.2g Å is %.3g times the exposure used for this "
+            "data collection.",
             target, recommendation,
         )
 
     summary = "\nRecommendations, summarised:\n"
     summary += tabulate(
         recommendations,
-        [u"Resolution (Å)", "Suggested\ndose factor"],
+        [u"Resolution (Å)", "Suggested\nexposure factor"],
         floatfmt=(".2g", ".3g"),
         tablefmt="rst",
     )
+    summary += u"\nExposure is flux × exposure time." \
+               "\nYou can achieve your desired exposure factor by modifying " \
+               "transmission and/or exposure time."
     info(summary)
 
     # Draw the Wilson plot image and save to file
@@ -404,7 +408,7 @@ def suggest_minimum_dose(expts, refls, params):
         d_star_sq,
         intensity,
         fit,
-        max_d=params.minimum_dose.wilson_fit_max_d,
+        max_d=params.minimum_exposure.wilson_fit_max_d,
         ticks=d_ticks,
         output=params.output.wilson_plot,
     )
@@ -416,7 +420,7 @@ def run(phil=phil_scope, args=None, set_up_logging=False):
     Parse command-line arguments, run the script.
 
     Uses the DIALS option parser to extract an experiment list, reflection table and
-    parameters, then passes them to :func:`suggest_minimum_dose`.
+    parameters, then passes them to :func:`suggest_minimum_exposure`.
     Optionally, sets up the logger.
 
     Args:
@@ -475,7 +479,7 @@ def run(phil=phil_scope, args=None, set_up_logging=False):
             params.input.experiments[0].filename,
         )
 
-    suggest_minimum_dose(expts, refls, params)
+    suggest_minimum_exposure(expts, refls, params)
 
 
 def main():

--- a/screen19/minimum_exposure.py
+++ b/screen19/minimum_exposure.py
@@ -385,7 +385,7 @@ def suggest_minimum_exposure(expts, refls, params):
                 target,
             )
         debug(
-            "The estimated minimal sufficient exposure (flux × exposure time) to "
+            u"The estimated minimal sufficient exposure (flux × exposure time) to "
             u"achievea resolution of %.2g Å is %.3g times the exposure used for this "
             "data collection.",
             target, recommendation,

--- a/screen19/minimum_exposure.py
+++ b/screen19/minimum_exposure.py
@@ -6,7 +6,7 @@ Reflection d-spacings are determined from the crystal symmetry (from
 indexing) and the Miller indices of the indexed reflections.  The
 atomic displacement parameter is assumed isotropic.  Its value is
 determined from a fit to the reflection data:
-  I = A * exp(-B /(2 * d^2)),
+  I = A * exp(-B / (2 * d^2)),
 where I is the intensity and the scale factor, A, and isotropic
 displacement parameter, B, are the fitted parameters.
 
@@ -136,11 +136,11 @@ debug, info, warn = logger.debug, logger.info, logger.warning
 def scaled_debye_waller(x, b, a):
     # type: (float, float, float) -> float
     u"""
-    A scaled isotropic Debye-Waller factor
+    Calculate a scaled isotropic Debye-Waller factor.
 
     By assuming a single isotropic disorder parameter, :param:`b`, this factor
-    approximates the decay of diffracted X-ray intensity increasing resolution (
-    decreasing d, increasing sin(θ)).
+    approximates the decay of diffracted X-ray intensity increasing resolution
+    (decreasing d, increasing sin(θ)).
 
     Args:
         x: Equivalent to 1/d².
@@ -484,7 +484,5 @@ def run(phil=phil_scope, args=None, set_up_logging=False):
 
 def main():
     # type: () -> None
-    """
-    Dispatcher for command-line call.
-    """
+    """Dispatcher for command-line call."""
     run(set_up_logging=True)

--- a/screen19/minimum_exposure.py
+++ b/screen19/minimum_exposure.py
@@ -41,7 +41,8 @@ import sys
 import logging
 import numpy as np
 from tabulate import tabulate
-from typing import Iterable, List, Optional, Sequence, Union
+from typing import Iterable, List, Optional, Sequence, Union  # noqa: F401
+# Flake8 does not detect typing yet (https://gitlab.com/pycqa/flake8/issues/342)
 
 import boost.python
 from cctbx import crystal, miller

--- a/screen19/screen.py
+++ b/screen19/screen.py
@@ -52,6 +52,7 @@ import re
 import sys
 import time
 import timeit
+from glob import glob
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from dials.array_family import flex
@@ -452,8 +453,6 @@ class Screen19(object):
 
             Use some filleted bits of dials.import and dials.util.options.Importer.
             """
-            from glob import glob
-
             from dxtbx.model.experiment_list import BeamComparison, \
                 DetectorComparison, GoniometerComparison, ExperimentListFactory, \
                 ExperimentListTemplateImporter

--- a/screen19/screen.py
+++ b/screen19/screen.py
@@ -405,7 +405,8 @@ class Screen19(object):
                 try:
                     self.expts = ExperimentList.from_file(files[0])
                     self.params.dials_import.output.experiments = files[0]
-                    return
+                    if self.expts:
+                        return
                 except Exception:  # TODO: can we be more specific?
                     pass
 
@@ -598,6 +599,8 @@ class Screen19(object):
                 warn("Could not determine number of images in dataset")
                 sys.exit(1)
 
+        # FIXME:  This exception handling should be redundant.  Empty experiment
+        #         lists should get caught at the import stage.  Is this so?
         try:
             return self.expts[0].imageset.size()
         except IndexError:

--- a/screen19/screen.py
+++ b/screen19/screen.py
@@ -332,7 +332,7 @@ class Screen19(object):
         """
         debug("Quick import template summary:\n\t%s", templates)
         if len(templates) > 1:
-            debug("Cannot currently run quick import on multiple templates")
+            debug("Cannot currently run quick import on multiple templates.")
             return False
 
         try:
@@ -340,10 +340,10 @@ class Screen19(object):
             if not scan_range:
                 raise IndexError
         except IndexError:
-            debug("Cannot run quick import: could not determine image naming template")
+            debug("Cannot run quick import: could not determine image naming template.")
             return False
 
-        info("Running quick import")
+        info("Running quick import.")
         if screen19.dials_v1:
             self._run_dials_import(
                 [
@@ -395,7 +395,7 @@ class Screen19(object):
                 if not self._quick_import_templates([(template, (start, end))]):
                     warn("Could not import specified image range.")
                     sys.exit(1)
-                info("Quick import successful")
+                info("Quick import successful.")
                 return
             elif not screen19.dials_v1 and files[0].endswith(".expt"):
                 debug(
@@ -412,7 +412,7 @@ class Screen19(object):
 
         # Can the files be quick-imported?
         if self._quick_import(files):
-            info("Quick import successful")
+            info("Quick import successful.")
             return
 
         if screen19.dials_v1:
@@ -596,7 +596,7 @@ class Screen19(object):
             try:
                 return sum(len(s["exposure_time"]) for s in datablock[0]["scan"])
             except Exception:
-                warn("Could not determine number of images in dataset")
+                warn("Could not determine number of images in dataset.")
                 sys.exit(1)
 
         # FIXME:  This exception handling should be redundant.  Empty experiment
@@ -604,7 +604,7 @@ class Screen19(object):
         try:
             return self.expts[0].imageset.size()
         except IndexError:
-            warn("Could not determine number of images in dataset")
+            warn("Could not determine number of images in dataset.")
             sys.exit(1)
 
     def _check_intensities(self, mosaicity_correction=True):  # type: (bool) -> None
@@ -1240,7 +1240,7 @@ class Screen19(object):
         n_images = self._count_images()
         fast_mode = n_images < 10
         if fast_mode:
-            info("%d images found, skipping a lot of processing", n_images)
+            info("%d images found, skipping a lot of processing.", n_images)
 
         self._find_spots()
 
@@ -1316,7 +1316,7 @@ class Screen19(object):
             time.strftime("%Y-%m-%d %H:%M:%S"),
             runtime,
         )
-        info("screen19 successfully completed (%.1f sec)", runtime)
+        info("screen19 successfully completed (%.1f sec).", runtime)
 
 
 def main():  # type: () -> None

--- a/screen19/screen.py
+++ b/screen19/screen.py
@@ -73,7 +73,6 @@ Templates = List[Tuple[str, Tuple[int, int]]]
 
 help_message = __doc__
 
-
 if screen19.dials_v1:
     verbosity_scope = u'''
     verbosity = 1
@@ -122,7 +121,7 @@ phil_scope = iotbx.phil.parse(
         .help = "The chosen value will apply to all the DIALS utilities with a "
                 "multi-processing option.  If 'False' or 'Auto', all available "
                 "processors will be used."
-    
+
     minimum_exposure
         .caption = 'Options for screen19.minimum_exposure'
         {
@@ -134,7 +133,7 @@ phil_scope = iotbx.phil.parse(
                     'indexed (quicker) or integrated (better) data in fitting '
                     'the isotropic displacement parameter.'
         }
-    
+
     maximum_flux
         .caption = 'Options for avoiding detector paralysation'
         {
@@ -151,16 +150,16 @@ phil_scope = iotbx.phil.parse(
                     "sensible to present the user with a correspondingly reduced upper-"
                     "limit flux recommendation."
         }
-    
+
     dials_import
         .caption = 'Options for dials.import'
         {
         include scope dials.command_line.dials_import.phil_scope
-        
+
         input
             {
-            include scope dials.util.options.tolerance_phil_scope 
-            
+            include scope dials.util.options.tolerance_phil_scope
+
             experiments = None
                 .help = "The experiment list file path"
                 .type = str
@@ -168,43 +167,43 @@ phil_scope = iotbx.phil.parse(
                 .optional = True
             }
         }
-    
+
     dials_find_spots
         .caption = 'Options for dials.find_spots'
         {
         include scope dials.command_line.find_spots.phil_scope
         }
-    
+
     dials_index
         .caption = 'Options for dials.index'
         {
         include scope dials.command_line.index.phil_scope
         }
-    
+
     dials_refine
         .caption = 'Options for dials.refine'
         {
         include scope dials.command_line.refine.phil_scope
         }
-    
+
     dials_refine_bravais
         .caption = 'Options for dials.refine_bravais_settings'
         {
         include scope dials.command_line.refine_bravais_settings.phil_scope
         }
-    
+
     dials_create_profile
         .caption = 'Options for dials.create_profile_model'
         {
         include scope dials.command_line.create_profile_model.phil_scope
         }
-    
+
     dials_integrate
         .caption = 'Options for dials.integrate'
         {
         include scope dials.command_line.integrate.phil_scope
         }
-    
+
     dials_report
         .caption = 'Options for dials.report'
         {
@@ -221,9 +220,7 @@ debug, info, warn = logger.debug, logger.info, logger.warn
 
 
 def _reset_cache():  # type: () -> None
-    """
-    Work around DIALS <1.14.4 phil cache issue
-    """
+    """Work around DIALS <1.14.4 phil cache issue."""
     import dials.util.phil
 
     dcr = dials.util.phil.default_converter_registry
@@ -235,7 +232,7 @@ def _reset_cache():  # type: () -> None
 def overloads_histogram(d_spacings, ticks=None, output="overloads"):
     # type: (Sequence[float], Optional[Sequence[float]], Optional[str]) -> None
     """
-    Generate a histogram of reflection d-spacings as an image, default is .png
+    Generate a histogram of reflection d-spacings as an image, default is .png.
 
     Args:
         d_spacings:  d-spacings of the reflections.
@@ -259,9 +256,7 @@ def overloads_histogram(d_spacings, ticks=None, output="overloads"):
 
 
 class Screen19(object):
-    """
-    Encapsulates the screening script.
-    """
+    """Encapsulates the screening script."""
 
     def __init__(self):
         if not screen19.dials_v1:
@@ -383,7 +378,7 @@ class Screen19(object):
                     os.path.join(files[0], f)
                     for f in os.listdir(files[0])
                     if f.endswith(".cbf") or f.endswith(".cbf.gz")
-                    or f.endswith(".cbf.bz2")
+                       or f.endswith(".cbf.bz2")
                 ]
             elif len(files[0].split(":")) == 3:
                 debug(
@@ -588,7 +583,6 @@ class Screen19(object):
         Returns:
             Number of images.
         """
-
         if screen19.dials_v1:
             with open(self.json_file) as fh:
                 datablock = json.load(fh)
@@ -652,11 +646,11 @@ class Screen19(object):
             if self._sigma_m:
                 delta_z = self._oscillation / self._sigma_m / math.sqrt(2)
                 average_to_peak = (
-                    (
-                        math.sqrt(math.pi) * delta_z * math.erf(delta_z)
-                        + math.exp(-delta_z**2) - 1
-                    )
-                    / delta_z**2
+                        (
+                                math.sqrt(math.pi) * delta_z * math.erf(delta_z)
+                                + math.exp(-delta_z ** 2) - 1
+                        )
+                        / delta_z ** 2
                 )
                 info("Average-to-peak intensity ratio: %f", average_to_peak)
 
@@ -709,8 +703,8 @@ class Screen19(object):
         else:
             info(text)
         if (
-            "overload_limit" in overload_data
-            and max_count >= overload_data["overload_limit"]
+                "overload_limit" in overload_data
+                and max_count >= overload_data["overload_limit"]
         ):
             warn(
                 "Warning: THE DATA CONTAIN REGULAR OVERLOADS!\n"
@@ -1059,9 +1053,7 @@ class Screen19(object):
         return False
 
     def _integrate(self):  # type: () -> None
-        """
-        Run `dials.integrate` to integrate reflection intensities.
-        """
+        """Run `dials.integrate` to integrate reflection intensities."""
         dials_start = timeit.default_timer()
         info("\nIntegrating...")
 
@@ -1251,7 +1243,7 @@ class Screen19(object):
                 self._find_spots(["sigma_strong=15"])
             else:
                 strong_refls = self.refls
-                self.params.dials_find_spots.spotfinder.threshold.dispersion\
+                self.params.dials_find_spots.spotfinder.threshold.dispersion \
                     .sigma_strong = 15
                 self._find_spots()
 
@@ -1319,4 +1311,5 @@ class Screen19(object):
 
 
 def main():  # type: () -> None
+    """Dispatcher for command-line call."""
     Screen19().run(set_up_logging=True)

--- a/screen19/screen.py
+++ b/screen19/screen.py
@@ -458,6 +458,7 @@ class Screen19(object):
                 ExperimentListTemplateImporter
             from dials.command_line.dials_import import MetaDataUpdater
 
+            # Get some key data format arguments.
             try:
                 format_kwargs = {
                     "dynamic_shadowing":
@@ -476,6 +477,8 @@ class Screen19(object):
                     args.append(arg)
 
             if args:
+                # Are compare{beam,detector,goniometer} and scan_tolerance necessary?
+                # They are cargo-culted from the DIALS option parser.
                 compare_beam = BeamComparison(
                     wavelength_tolerance=self.params.dials_import.input.tolerance.beam
                         .wavelength,
@@ -505,6 +508,7 @@ class Screen19(object):
                 scan_tolerance = \
                     self.params.dials_import.input.tolerance.scan.oscillation
 
+                # Import an experiment list from image data.
                 experiments = ExperimentListFactory.from_filenames(
                     args,
                     compare_beam=compare_beam,
@@ -514,6 +518,8 @@ class Screen19(object):
                     format_kwargs=format_kwargs,
                 )
 
+                # Record the imported experiments for use elsewhere.
+                # Quit if there aren't any.
                 self.expts.extend(experiments)
                 if not self.expts:
                     warn("No images found.")
@@ -526,7 +532,9 @@ class Screen19(object):
                         self.params.dials_import.input.template,
                         format_kwargs=format_kwargs
                     )
-                    self.expts = importer.experiments
+                    # Record the imported experiments for use elsewhere.
+                    # Quit if there aren't any.
+                    self.expts.extend(importer.experiments)
                     if not self.expts:
                         warn(
                             "No images found matching template %s"

--- a/screen19/screen.py
+++ b/screen19/screen.py
@@ -53,7 +53,8 @@ import sys
 import time
 import timeit
 from glob import glob
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple  # noqa: F401
+# Flake8 does not detect typing yet (https://gitlab.com/pycqa/flake8/issues/342)
 
 from dials.array_family import flex
 from dials.util import log, Sorry

--- a/screen19/screen.py
+++ b/screen19/screen.py
@@ -1294,6 +1294,9 @@ class Screen19(object):
 
         self._refine_bravais(experiments, reflections)
 
+        if not fast_mode:
+            self._report(experiments, reflections)
+
         runtime = timeit.default_timer() - start
         debug(
             "Finished at %s, total runtime: %.1f",
@@ -1301,9 +1304,6 @@ class Screen19(object):
             runtime,
         )
         info("screen19 successfully completed (%.1f sec)", runtime)
-
-        if not fast_mode:
-            self._report(experiments, reflections)
 
 
 def main():  # type: () -> None

--- a/setup.py
+++ b/setup.py
@@ -27,16 +27,16 @@ setup(
             "screen19 = screen19.screen:main",
             "i19.stability_fft = screen19.stability_fft:main",
             "i19.sync = screen19.sync:main",
-            "i19.minimum_dose = screen19.minimum_dose:main",
-            "screen19.minimum_dose = screen19.minimum_dose:main"
+            "i19.minimum_exposure = screen19.minimum_exposure:main",
+            "screen19.minimum_exposure = screen19.minimum_exposure:main"
         ],
         "libtbx.dispatcher.script": [
             "i19.screen = i19.screen",
             "screen19 = screen19",
             "i19.stability_fft = i19.stability_fft",
             "i19.sync = i19.sync",
-            "i19.minimum_dose = i19.minimum_dose",
-            "screen19.minimum_dose = screen19.minimum_dose"
+            "i19.minimum_exposure = i19.minimum_exposure",
+            "screen19.minimum_exposure = screen19.minimum_exposure"
         ],
         "libtbx.precommit": ["screen19 = screen19"],
     },

--- a/setup.py
+++ b/setup.py
@@ -27,16 +27,16 @@ setup(
             "screen19 = screen19.screen:main",
             "i19.stability_fft = screen19.stability_fft:main",
             "i19.sync = screen19.sync:main",
-            "i19.minimum_flux = screen19.minimum_flux:main",
-            "screen19.minimum_flux = screen19.minimum_flux:main"
+            "i19.minimum_dose = screen19.minimum_dose:main",
+            "screen19.minimum_dose = screen19.minimum_dose:main"
         ],
         "libtbx.dispatcher.script": [
             "i19.screen = i19.screen",
             "screen19 = screen19",
             "i19.stability_fft = i19.stability_fft",
             "i19.sync = i19.sync",
-            "i19.minimum_flux = i19.minimum_flux",
-            "screen19.minimum_flux = screen19.minimum_flux"
+            "i19.minimum_dose = i19.minimum_dose",
+            "screen19.minimum_dose = screen19.minimum_dose"
         ],
         "libtbx.precommit": ["screen19 = screen19"],
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,8 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 try:
-    from dials_data import *
+    import dials_data as _  # noqa: F401
 except ImportError:
-
-    @pytest.fixture
+    @pytest.fixture(scope="session")
     def dials_data():
         pytest.skip("Test requires python package dials_data")

--- a/tests/test_screen19.py
+++ b/tests/test_screen19.py
@@ -19,6 +19,36 @@ def test_screen19(dials_data, tmpdir):
     assert "photon incidence rate is outside the linear response region" in logfile
 
 
+data_files = [
+    [""],
+    ["x3_1_00*.cbf.gz"],
+    ["x3_1_####.cbf.gz:1:99"],
+    ["x3_1_00##.cbf.gz:1:99"],
+    ["x3_1_0001.cbf.gz:1:99"],
+    [
+        "x3_1_0001.cbf.gz",
+        "x3_1_0002.cbf.gz",
+        "x3_1_0003.cbf.gz",
+        "x3_1_0004.cbf.gz",
+        "x3_1_0005.cbf.gz",
+    ],
+]
+@pytest.mark.parametrize("data_files", data_files)
+def test_screen19_inputs(dials_data, tmpdir, data_files):
+    """Test various valid input argument styles"""
+    data = [
+        dials_data("small_molecule_example").join(filename).strpath
+        for filename in data_files
+    ]
+
+    with tmpdir.as_cwd():
+        Screen19().run(data, set_up_logging=True)
+
+    logfile = tmpdir.join("screen19.log").read()
+
+    assert "screen19 successfully completed" in logfile
+
+
 @pytest.mark.xfail(raises=ValueError, reason="LAPACK bug?")
 def test_screen19_single_frame(dials_data, tmpdir):
     # TODO Use a single frame with fewer than 80 reflections


### PR DESCRIPTION
- Change name `screen19.minimum_flux` to more accurate `screen19.minimum_dose`.
- Allow processing of `.cbf.gz` and `.cbf.bz2` files, as well as `.cbf`s.
- Adapt to logging changes in DIALS v2.
- Adapt to file name convention changes in DIALS v2.
- Use functional interface to DIALS algorithms where possible.
- Print unicode output, except in Gnuplot ProcRunner call.
- Flesh out tests somewhat.
￼
Fixes #14.