### PR TITLE
Fix screen19 for few images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ eggs/
 lib/
 lib64/
 parts/
+pip-wheel-metadata/
 sdist/
 var/
 *.egg-info/

--- a/newsfragments/29.bugfix
+++ b/newsfragments/29.bugfix
@@ -1,0 +1,2 @@
+Perform French-Wilson scaling on the integrated intensities before performing the Wilson plot analysis.
+This fixes screen19 failures for certain cases where the data consist of few reflections.

--- a/screen19/screen.py
+++ b/screen19/screen.py
@@ -1055,11 +1055,6 @@ class Screen19(object):
         self._import(unhandled)
         imported_name = self.params.dials_import.output.experiments
 
-        n_images = self._count_images()
-        fast_mode = n_images < 10
-        if fast_mode:
-            info("%d images found, skipping a lot of processing.", n_images)
-
         self._find_spots()
 
         if not self._index():
@@ -1088,7 +1083,7 @@ class Screen19(object):
                 )
                 sys.exit(1)
 
-        if not fast_mode and not self._create_profile_model():
+        if not self._create_profile_model():
             info("\nRefining model to attempt to increase number of valid spots...")
             self._refine()
             if not self._create_profile_model():
@@ -1101,8 +1096,7 @@ class Screen19(object):
                 )
                 sys.exit(1)
 
-        if not fast_mode:
-            self._check_intensities()
+        self._check_intensities()
 
         if self.params.minimum_exposure.data == "integrated":
             self._integrate()
@@ -1123,8 +1117,7 @@ class Screen19(object):
         else:
             self._refine_bravais()
 
-        if not fast_mode:
-            self._report(experiments, reflections)
+        self._report(experiments, reflections)
 
         runtime = timeit.default_timer() - start
         debug(

--- a/tests/test_screen19.py
+++ b/tests/test_screen19.py
@@ -83,7 +83,6 @@ def test_screen19(dials_data, tmpdir):
 
 
 def test_screen19_single_frame(dials_data, tmpdir):
-    # TODO Use a single frame with fewer than 80 reflections
     image = dials_data("x4wide").join("X4_wide_M1S4_2_0001.cbf").strpath
 
     with tmpdir.as_cwd():


### PR DESCRIPTION
Currently, if screen19 is called on a sweep of fewer than ten images, it runs in `fast_mode`, which bypasses profile modelling (and also `dials.report`).  However, this is a poor heuristic for determining that profile modelling will fail.  In fact, it is usually possible to create an adequate profile model from a single image, as demonstrated below.  In any case, we can default to using summation intensities for the Wilson plot analysis if we need to.

This PR also introduces French-Wilson scaling of the integrated intensities, to boost the number of valid reflections.  Currently, reflections with negative intensity are simply discarded.  This is probably because I wrote this code before I knew anything much about crystallography and had never heard of French-Wilson scaling.  It seems much more sensible to use it.

##### Profile modelling on single images with DIALS
To demonstrate that `dials.create_profile_model` can produce a workable profile model from even just a single image, I ran the following minimal processing routine on each image from [the `x4wide` test data set](https://github.com/dials/data/blob/62b3fd9bcc237b9f21c2fe8caae69305cb540f75/dials_data/definitions/x4wide.yml):
```
dials.import <image> &&
  dials.find_spots imported.expt &&
  dials.index imported.expt strong.refl &&
  dials.create_profile_model indexed.*
```
I also ran the same routine on the entire sweep together, to get the 'true' profile model for comparison.  The results are shown in this plot, with each datum corresponding to a single image, and dashed lines to the full-sweep values.

![figure](https://user-images.githubusercontent.com/11389015/85047081-42f1cc00-b189-11ea-89e2-a21ad07764bb.png)

Unsurprisingly, the beam divergence is well determined from a single image but the mosaicity determination is poor.  Not as poor as one might expect from a single image though, and the error is systematic — the precision is fairly good, even if the accuracy is not.  In any case, since profile-fitted integration will fail for a single image, we will default to summed intensities anyway and it doesn't matter that the estimate of mosaicity is a poor reflection of the true value.