### PR TITLE
Update import sorting behaviour

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,4 @@ known_cctbx="boost,boost_adaptbx,cbflib_adaptbx,cctbx,chiltbx,clipper_adaptbx,cm
 known_dxtbx="dxtbx"
 known_dials="dials"
 known_xia2="xia2"
-float_to_top=true
 profile="black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,7 @@ package_dir = ".."
 filename = "CHANGELOG.rst"
 
 [tool.isort]
-sections="FUTURE,STDLIB,THIRDPARTY,CCTBX,DXTBX,DIALS,XIA2,FIRSTPARTY,LOCALFOLDER"
+sections="FUTURE,STDLIB,THIRDPARTY,CCTBX,DIALS,FIRSTPARTY,LOCALFOLDER"
 known_cctbx="boost,boost_adaptbx,cbflib_adaptbx,cctbx,chiltbx,clipper_adaptbx,cma_es,cootbx,crys3d,cudatbx,fable,fast_linalg,fftw3tbx,gltbx,iota,iotbx,libtbx,mmtbx,omptbx,prime,rstbx,scitbx,simtbx,smtbx,spotfinder,tbxx,ucif,wxtbx,xfel"
-known_dxtbx="dxtbx"
-known_dials="dials"
-known_xia2="xia2"
+known_dials="dxtbx,dials,xia2"
 profile="black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,10 @@ package_dir = ".."
 filename = "CHANGELOG.rst"
 
 [tool.isort]
+sections="FUTURE,STDLIB,THIRDPARTY,CCTBX,DXTBX,DIALS,XIA2,FIRSTPARTY,LOCALFOLDER"
 known_cctbx="boost,boost_adaptbx,cbflib_adaptbx,cctbx,chiltbx,clipper_adaptbx,cma_es,cootbx,crys3d,cudatbx,fable,fast_linalg,fftw3tbx,gltbx,iota,iotbx,libtbx,mmtbx,omptbx,prime,rstbx,scitbx,simtbx,smtbx,spotfinder,tbxx,ucif,wxtbx,xfel"
-sections="FUTURE,STDLIB,THIRDPARTY,CCTBX,FIRSTPARTY,LOCALFOLDER"
-# Explicitly black-compatible settings
-multi_line_output=3
-include_trailing_comma=true
-force_grid_wrap=0
-use_parentheses=true
-line_length=88
-ensure_newline_before_comments=true
+known_dxtbx="dxtbx"
+known_dials="dials"
+known_xia2="xia2"
+float_to_top=true
+profile="black"


### PR DESCRIPTION
 - ~Run `pre-commit autoupdate`.~
 - ~Add isort `known_dials` imports category, including `dials`, `dxtbx` and `xia2`.~
 - ~Run pre-commit hooks on all files with `pre-commit run --all-files`.~

Change of plan.  Leave the updating of pre-commit hooks to the new GitHub workflow (see #36).

### Update isort behaviour

 • Create separate groups for CCTBX, DXTBX, DIALS & xia2.
 • Use the new profile for compatibility with Black.
 • Float all imports with isort.

Since isort version 5, the default behaviour is not to float imports
unless explicitly configured to do so.  See
https://pycqa.github.io/isort/docs/major_releases/introducing_isort_5/#sort-imports-anywhere
and
https://pycqa.github.io/isort/docs/configuration/options/#float-to-top

Note that indented imports are not floated.