### PR TITLE
Create a workflow to automatically update pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -37,7 +37,7 @@ jobs:
           pre-commit autoupdate
           until pre-commit run --all-files
           do
-            echo "Re-running pre-commits..."
+            printf "\nRe-running pre-commits...\n"
           done
 
       - name: Create pull request

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -25,16 +25,19 @@ jobs:
       - name: Install pre-commit
         run: pip install pre-commit
 
-      - name: ${{ github.action.name }}
+      - name: ${{ github.workflow }}
         run: |
           pre-commit autoupdate
-          pre-commit run --all-files
+          until pre-commit run --all-files
+          do
+            echo "Re-running pre-commits..."
+          done
 
       - name: Create a new branch pre-commit-autoupdate and push the changes to it
         run: |
           git checkout -B ${{ steps.branch.branchname }}
           git add .
-          git commit -m "${{ github.action.name }}"
+          git commit -m "${{ github.workflow }}"
           git push -fu origin ${{ steps.branch.branchname }}
 
       - name: Create pull request
@@ -43,8 +46,8 @@ jobs:
         with:
           branch: pre-commit-autoupdate
           base: master
-          commit-message: ${{ github.action.name }}
-          title: ${{ github.action.name }}
+          commit-message: ${{ github.workflow }}
+          title: ${{ github.workflow }}
 
       - name: Set the file name for the Towncrier news fragment
         id: newsfile
@@ -52,7 +55,7 @@ jobs:
 
       - name: Make a Towncrier news fragment and push it to the branch
         run: |
-          echo "${{ github.action.name }}" > ${{ steps.newsfile.filename }}
+          echo "${{ github.workflow }}" > ${{ steps.newsfile.filename }}
           git add ${{ steps.newsfile.filename }}
           git commit -m "Add news fragment"
           git push origin ${{ steps.branch.branchname }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -57,6 +57,7 @@ jobs:
         run: echo "::set-output name=filename::${{ steps.pr.outputs.pull-request-number }}.misc"
 
       - name: Make a Towncrier news fragment and push it to the branch
+        if: ${{ steps.pr.outputs.pull-request-number }}
         run: |
           echo "${{ github.workflow }}" > ${{ steps.newsfile.outputs.filename }}
           git add ${{ steps.newsfile.outputs.filename }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -9,12 +9,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  # This workflow contains a single job called "autoupdate".
+  # This workflow contains a single job called 'autoupdate'.
   autoupdate:
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out the repository
+        # Don't use release tags for actions:  https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
+        # Commit is equivalent to release tag v2.3.2.
         uses: actions/checkout@2036a08e25fa78bbd946711a407b529a0a1204bf
 
       - name: Set the name of the branch for these changes
@@ -22,6 +24,7 @@ jobs:
         run: echo "::set-output name=branchname::pre-commit-autoupdate"
 
       - name: Set up Python
+        # Commit is equivalent to release tag v2.1.2.
         uses: actions/setup-python@24156c231c5e9d581bde27d0cdbb72715060ea51
         with:
           python-version: '>=3'
@@ -39,6 +42,7 @@ jobs:
 
       - name: Create pull request
         id: pr
+        # Commit is equivalent to release tag v3.2.0.
         uses: peter-evans/create-pull-request@9bf4b302a561e1fe9120f6dc81cc39daed984a99
         with:
           branch: ${{ steps.branch.outputs.branchname }}
@@ -48,11 +52,13 @@ jobs:
 
       - name: Set the file name for the Towncrier news fragment
         id: newsfile
+        # Only run if the PR exists.
         if: ${{ steps.pr.outputs.pull-request-number }}
         run: echo "::set-output name=filename::${{ steps.pr.outputs.pull-request-number }}.misc"
 
       - name: Make a Towncrier news fragment and push it to the branch
-        if: ${{ steps.pr.outputs.pull-request-number }}
+        # Only run if the PR exists and there isn't already a news fragment.
+        if: ${{ steps.newsfile.outputs.filename }} && [[ ! -e ${{ steps.newsfile.outputs.filename }} ]]
         run: |
           echo "${{ github.workflow }}." > ${{ steps.newsfile.outputs.filename }}
           git config user.name "GitHub"

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -35,10 +35,10 @@ jobs:
 
       - name: Create a new branch pre-commit-autoupdate and push the changes to it
         run: |
-          git checkout -B ${{ steps.branch.branchname }}
+          git checkout -B "${{ steps.branch.branchname }}"
           git add .
           git commit -m "${{ github.workflow }}"
-          git push -fu origin ${{ steps.branch.branchname }}
+          git push -fu origin "${{ steps.branch.branchname }}"
 
       - name: Create pull request
         id: pr
@@ -55,7 +55,7 @@ jobs:
 
       - name: Make a Towncrier news fragment and push it to the branch
         run: |
-          echo "${{ github.workflow }}" > ${{ steps.newsfile.filename }}
-          git add ${{ steps.newsfile.filename }}
+          echo "${{ github.workflow }}" > "${{ steps.newsfile.filename }}"
+          git add "${{ steps.newsfile.filename }}"
           git commit -m "Add news fragment"
-          git push origin ${{ steps.branch.branchname }}
+          git push origin "${{ steps.branch.branchname }}"

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: >3
 
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip3 install pre-commit
 
       - name: ${{ github.action }}
         run: |

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,25 +1,28 @@
 name: Automatically update and run pre-commit hooks
 
-# Run daily at midnight.
 on:
+  # Run daily at midnight.
+  schedule:
+    - cron: '0 0 * * *'
+
+  # Also enable running manually.
   workflow_dispatch:
-  # schedule:
-  #   - cron: '*/5 * * * *'
 
 jobs:
-  # This workflow contains a single job called "autoupdate"
+  # This workflow contains a single job called "autoupdate".
   autoupdate:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out the repository
+        uses: actions/checkout@2036a08e25fa78bbd946711a407b529a0a1204bf
 
       - name: Set the name of the branch for these changes
         id: branch
         run: echo "::set-output name=branchname::pre-commit-autoupdate"
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@24156c231c5e9d581bde27d0cdbb72715060ea51
         with:
           python-version: '>=3'
 
@@ -36,7 +39,7 @@ jobs:
 
       - name: Create pull request
         id: pr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@9bf4b302a561e1fe9120f6dc81cc39daed984a99
         with:
           branch: ${{ steps.branch.outputs.branchname }}
           commit-message: ${{ github.workflow }}
@@ -51,7 +54,7 @@ jobs:
       - name: Make a Towncrier news fragment and push it to the branch
         if: ${{ steps.pr.outputs.pull-request-number }}
         run: |
-          echo "${{ github.workflow }}" > ${{ steps.newsfile.outputs.filename }}
+          echo "${{ github.workflow }}." > ${{ steps.newsfile.outputs.filename }}
           git config user.name "GitHub"
           git config user.email "noreply@github.com"
           git checkout ${{ steps.branch.outputs.branchname }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -2,8 +2,9 @@ name: Automatically update and run pre-commit hooks
 
 # Run daily at midnight.
 on:
-  schedule:
-    - cron: '*/5 * * * *'
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '*/5 * * * *'
 
 jobs:
   # This workflow contains a single job called "autoupdate"

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -57,8 +57,8 @@ jobs:
         run: echo "::set-output name=filename::${{ steps.pr.outputs.pull-request-number }}.misc"
 
       - name: Make a Towncrier news fragment and push it to the branch
-        # Only run if the PR exists and there isn't already a news fragment.
-        if: ${{ steps.newsfile.outputs.filename }} && [[ ! -e ${{ steps.newsfile.outputs.filename }} ]]
+        # Only run if the PR exists.
+        if: ${{ steps.newsfile.outputs.filename }}
         run: |
           echo "${{ github.workflow }}." > ${{ steps.newsfile.outputs.filename }}
           git config user.name "GitHub"

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -34,33 +34,26 @@ jobs:
             echo "Re-running pre-commits..."
           done
 
-      - name: Create a new branch pre-commit-autoupdate and push the changes to it
-        run: |
-          git config user.name "GitHub"
-          git config user.email "noreply@github.com"
-          git checkout -B ${{ steps.branch.outputs.branchname }}
-          git add .
-          git commit -m "${{ github.workflow }}"
-          git push -fu origin ${{ steps.branch.outputs.branchname }}
-          git checkout master
-
       - name: Create pull request
         id: pr
         uses: peter-evans/create-pull-request@v3
         with:
-          branch: pre-commit-autoupdate
-          base: master
+          branch: ${{ steps.branch.outputs.branchname }}
           commit-message: ${{ github.workflow }}
           title: ${{ github.workflow }}
+          body: Automated changes performed by a GitHub workflow.
 
       - name: Set the file name for the Towncrier news fragment
         id: newsfile
+        if: ${{ steps.pr.outputs.pull-request-number }}
         run: echo "::set-output name=filename::${{ steps.pr.outputs.pull-request-number }}.misc"
 
       - name: Make a Towncrier news fragment and push it to the branch
         if: ${{ steps.pr.outputs.pull-request-number }}
         run: |
           echo "${{ github.workflow }}" > ${{ steps.newsfile.outputs.filename }}
+          git config user.name "GitHub"
+          git config user.email "noreply@github.com"
           git checkout ${{ steps.branch.outputs.branchname }}
           git add ${{ steps.newsfile.outputs.filename }}
           git commit -m "Add news fragment"

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -23,9 +23,9 @@ jobs:
           python-version: >3
 
       - name: Install pre-commit
-        run: pip3 install pre-commit
+        run: pip install pre-commit
 
-      - name: ${{ github.action }}
+      - name: ${{ github.action.name }}
         run: |
           pre-commit autoupdate
           pre-commit run --all-files
@@ -34,7 +34,7 @@ jobs:
         run: |
           git checkout -B ${{ steps.branch.branchname }}
           git add .
-          git commit -m "${{ github.action }}"
+          git commit -m "${{ github.action.name }}"
           git push -fu origin ${{ steps.branch.branchname }}
 
       - name: Create pull request
@@ -43,8 +43,8 @@ jobs:
         with:
           branch: pre-commit-autoupdate
           base: master
-          commit-message: ${{ github.action }}
-          title: ${{ github.action }}
+          commit-message: ${{ github.action.name }}
+          title: ${{ github.action.name }}
 
       - name: Set the file name for the Towncrier news fragment
         id: newsfile
@@ -52,7 +52,7 @@ jobs:
 
       - name: Make a Towncrier news fragment and push it to the branch
         run: |
-          echo "${{ github.action }}" > ${{ steps.newsfile.filename }}
+          echo "${{ github.action.name }}" > ${{ steps.newsfile.filename }}
           git add ${{ steps.newsfile.filename }}
           git commit -m "Add news fragment"
           git push origin ${{ steps.branch.branchname }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Create a new branch pre-commit-autoupdate and push the changes to it
         run: |
+          git config user.name "GitHub"
+          git config user.email "noreply@github.com"
           git checkout -B ${{ steps.branch.outputs.branchname }}
           git add .
           git commit -m "${{ github.workflow }}"

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -35,10 +35,10 @@ jobs:
 
       - name: Create a new branch pre-commit-autoupdate and push the changes to it
         run: |
-          git checkout -B "${{ steps.branch.branchname }}"
+          git checkout -B ${{ steps.branch.outputs.branchname }}
           git add .
           git commit -m "${{ github.workflow }}"
-          git push -fu origin "${{ steps.branch.branchname }}"
+          git push -fu origin ${{ steps.branch.outputs.branchname }}
 
       - name: Create pull request
         id: pr
@@ -55,7 +55,7 @@ jobs:
 
       - name: Make a Towncrier news fragment and push it to the branch
         run: |
-          echo "${{ github.workflow }}" > "${{ steps.newsfile.filename }}"
-          git add "${{ steps.newsfile.filename }}"
+          echo "${{ github.workflow }}" > ${{ steps.newsfile.outputs.filename }}
+          git add ${{ steps.newsfile.outputs.filename }}
           git commit -m "Add news fragment"
-          git push origin "${{ steps.branch.branchname }}"
+          git push origin ${{ steps.branch.outputs.branchname }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: >3
+          python-version: '>=3'
 
       - name: Install pre-commit
         run: pip install pre-commit

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -42,6 +42,7 @@ jobs:
           git add .
           git commit -m "${{ github.workflow }}"
           git push -fu origin ${{ steps.branch.outputs.branchname }}
+          git checkout master
 
       - name: Create pull request
         id: pr
@@ -60,6 +61,7 @@ jobs:
         if: ${{ steps.pr.outputs.pull-request-number }}
         run: |
           echo "${{ github.workflow }}" > ${{ steps.newsfile.outputs.filename }}
+          git checkout ${{ steps.branch.outputs.branchname }}
           git add ${{ steps.newsfile.outputs.filename }}
           git commit -m "Add news fragment"
           git push origin ${{ steps.branch.outputs.branchname }}


### PR DESCRIPTION
Create a workflow that runs daily at midnight, or can be triggered manually, and which does the following:
 - Checks out the repository.
 - Sets up Python.
 - Installs pre-commit with Pip.
 - Updates all pre-commit hooks with `pre-commit autoupdate`.
 - Repeatedly runs the pre-commit hooks on all files until there are no changes.
 - Commits any changes to a branch `pre-commit-autoupdate`.
 - Creates a Towncrier `.misc` news fragment for the pull request.

This time, I think it works...  See #34 & #35.