### PR TITLE
Compatibility fixes for procrunner 2.1.0

### DIFF
--- a/screen19/__init__.py
+++ b/screen19/__init__.py
@@ -73,6 +73,28 @@ def prettyprint_dictionary(d):
     )
 
 
+def prettyprint_procrunner(d):
+    """
+    Produce a nice string representation of a procrunner ReturnObject, for printing.
+
+    :param d: ReturnObject to be printed.
+    :return: String representation of :param d:.
+    :rtype: str
+    """
+    return prettyprint_dictionary(
+        {
+            "command": d.args,
+            "exitcode": d.returncode,
+            "stdout": d.stdout,
+            "stderr": d.stderr,
+            "time_start": d["time_start"],
+            "time_end": d["time_end"],
+            "runtime": d["runtime"],
+            "timeout": d["timeout"],
+        }
+    )
+
+
 def make_template(f):
     """
     Generate a xia2-style filename template.
@@ -160,7 +182,7 @@ def plot_intensities(
         info(traceback.format_exc())
         result = {}
 
-    debug("result = %s", prettyprint_dictionary(result))
+    debug("result = %s", prettyprint_procrunner(result))
 
     if result["exitcode"] == 0:
         star = re.compile(r"\*")

--- a/screen19/screen.py
+++ b/screen19/screen.py
@@ -582,7 +582,7 @@ class Screen19(object):
         command = ["xia2.overload", "nproc=%s" % self.nproc, "indexed.expt"]
         debug("running %s", command)
         result = procrunner.run(command, print_stdout=False, debug=procrunner_debug)
-        debug("result = %s", screen19.prettyprint_dictionary(result))
+        debug("result = %s", screen19.prettyprint_procrunner(result))
         info("Successfully completed (%.1f sec)", result["runtime"])
 
         if result["exitcode"] != 0:
@@ -878,7 +878,7 @@ class Screen19(object):
             "output = %s" % self.params.dials_index.output.experiments,
         ]
         result = procrunner.run(command, print_stdout=False, debug=procrunner_debug)
-        debug("result = %s", screen19.prettyprint_dictionary(result))
+        debug("result = %s", screen19.prettyprint_procrunner(result))
         self._sigma_m = None
         if result["exitcode"] == 0:
             db = ExperimentList.from_file(self.params.dials_index.output.experiments)[0]
@@ -946,7 +946,7 @@ class Screen19(object):
             info("\nRefining Bravais settings...")
             command = ["dials.refine_bravais_settings", experiments, reflections]
             result = procrunner.run(command, print_stdout=False, debug=procrunner_debug)
-            debug("result = %s", screen19.prettyprint_dictionary(result))
+            debug("result = %s", screen19.prettyprint_procrunner(result))
             if result["exitcode"] == 0:
                 m = re.search(
                     r"[-+]{3,}\n[^\n]*\n[-+|]{3,}\n(.*\n)*[-+]{3,}",
@@ -1010,7 +1010,7 @@ class Screen19(object):
         info("\nCreating report...")
         command = ["dials.report", experiments, reflections]
         result = procrunner.run(command, print_stdout=False, debug=procrunner_debug)
-        debug("result = %s", screen19.prettyprint_dictionary(result))
+        debug("result = %s", screen19.prettyprint_procrunner(result))
         if result["exitcode"] == 0:
             info("Successfully completed (%.1f sec)", result["runtime"])
         #     if sys.stdout.isatty():


### PR DESCRIPTION
the procrunner.run() return object is no longer a native dictionary (https://github.com/DiamondLightSource/python-procrunner/pull/60).
While dictionary access still works (and raises DeprecationWarnings) there is no implementation of `.items()`.

I ran the tests locally but two tests failed due to matplotlib 3.0.3 being either to new or to old. (would this be problem with a CCP4 installation? 7.1.3 currently has 2.2.3):
```
screen19/screen.py:1139: in run
    self._wilson_calculation()
screen19/screen.py:841: in _wilson_calculation
    suggest_minimum_exposure(self.expts, self.refls, self.params.minimum_exposure)
screen19/minimum_exposure.py:410: in suggest_minimum_exposure
    output=params.output.wilson_plot,
screen19/minimum_exposure.py:252: in wilson_plot_image
    plt.yscale("log", nonpositive="clip")
../../conda_base/lib/python3.6/site-packages/matplotlib/pyplot.py:3084: in yscale
    return gca().set_yscale(value, **kwargs)
../../conda_base/lib/python3.6/site-packages/matplotlib/axes/_base.py:3704: in set_yscale
    ax.yaxis._set_scale(value, **kwargs)
../../conda_base/lib/python3.6/site-packages/matplotlib/axis.py:767: in _set_scale
    self._scale = mscale.scale_factory(value, self, **kwargs)
../../conda_base/lib/python3.6/site-packages/matplotlib/scale.py:569: in scale_factory
    return _scale_mapping[scale](axis, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
E           ValueError: provided too many kwargs, can only pass {'basex', 'subsx', nonposx'} or {'basey', 'subsy', nonposy'}.  You passed {'nonpositive': 'clip'}
../../conda_base/lib/python3.6/site-packages/matplotlib/scale.py:249: ValueError
```