### PR TITLE
Refine: Only use centroids with non-zero variance

### DIFF
--- a/newsfragments/53.bugfix
+++ b/newsfragments/53.bugfix
@@ -1,0 +1,2 @@
+Fix a case of screen19 failing when trying to refine the different possible Bravais settings of the found lattice.
+This was happening because screen19 was failing to filter out reflections with zero variance in the position of their observed centroids before performing the refinement.

--- a/screen19/screen.py
+++ b/screen19/screen.py
@@ -981,9 +981,18 @@ class Screen19(object):
             self.refls = eliminate_sys_absent(self.expts, self.refls)
             map_to_primitive(self.expts, self.refls)
 
+            # We can only refine against reflections with non-zero variance in
+            # observed centroid position.
+            x_valid, y_valid, z_valid = [
+                part > 0 for part in self.refls["xyzobs.mm.variance"].parts()
+            ]
+            nonzero_variance = x_valid | y_valid | z_valid
+
             try:
                 refined_settings = refined_settings_from_refined_triclinic(
-                    self.expts, self.refls, self.params.dials_refine_bravais
+                    self.expts,
+                    self.refls.select(nonzero_variance),
+                    self.params.dials_refine_bravais,
                 )
             except RuntimeError as e:
                 warning("dials.refine_bravais_settings failed.\nGiving up.")


### PR DESCRIPTION
Don't refine experiment parameters from reflections with zero variance in observed centroid position.

Fixes #47.